### PR TITLE
share fragment between queries

### DIFF
--- a/creates/createProject.js
+++ b/creates/createProject.js
@@ -1,4 +1,5 @@
 const _ = require("lodash");
+const projectFragment = require('../fragments/project');
 
 const sample = {
   projectPk: 5,
@@ -13,13 +14,12 @@ const perform = (z, bundle) => {
       url: "https://api.marvelapp.com/graphql",
       body: {
         query: `
+          ${projectData}
           mutation createProject($projectName: String!, $companyPk: Int) {
             createProject(input: {name: $projectName, companyPk: $companyPk}) {
               ok
               project {
-                pk
-                name
-                prototypeUrl
+                ...projectData
               }
             }
           }
@@ -54,9 +54,13 @@ module.exports = {
     ],
     perform,
     outputFields: [
-      { key: "projectPk", label: "Project PK" },
-      { key: "projectUrl", label: "Project URL" },
-      { key: "projectName", label: "Project Name" }
+      { key: 'id', label: 'ID' },
+      { key: 'uuid', label: 'UUID' },
+      { key: 'name', label: 'Name' },
+      { key: 'prototypeUrl', label: 'Prototype URL' },
+      { key: 'isArchived', label: 'Is Archived' },
+      { key: 'createdAt', label: 'Created At' },
+      { key: 'modifiedAt', label: 'Modified At' },
     ]
   }
 };

--- a/fragments/project.js
+++ b/fragments/project.js
@@ -1,0 +1,15 @@
+module.exports = `
+fragment projectData on ProjectNode {
+    id: pk
+    uuid
+    name
+    prototypeUrl
+    isArchived
+    createdAt
+    modifiedAt
+    settings {
+    deviceFrame
+    portrait
+    }
+}
+`

--- a/triggers/project.js
+++ b/triggers/project.js
@@ -1,4 +1,5 @@
 const sample = require('../samples/sample_project');
+const projectFragment = require('../fragments/project');
 
 const triggerProject = (z, bundle) => {
   const responsePromise = z.request({
@@ -6,19 +7,7 @@ const triggerProject = (z, bundle) => {
     url: `https://api.marvelapp.com/graphql`,
     body: {
       query: `
-        fragment projectData on ProjectNode {
-          id: pk
-          uuid
-          name
-          prototypeUrl
-          isArchived
-          createdAt
-          modifiedAt
-          settings {
-            deviceFrame
-            portrait
-          }
-        }
+        ${projectFragment}
 
         query zapierGetProjects($first: Int!) {
           user {


### PR DESCRIPTION
Might break the existing zaps, shall we update the zaps or make the action keep returning `projectPk`, `projectName` & `projectURL`?